### PR TITLE
Lots of improvements

### DIFF
--- a/src/BabyKusto.Core/BabyKustoEngine.cs
+++ b/src/BabyKusto.Core/BabyKustoEngine.cs
@@ -45,7 +45,7 @@ namespace BabyKusto.Core
                     Console.WriteLine($"Kusto diagnostics: {diag.Severity} {diag.Code} {diag.Message} {diag.Description}");
                 }
 
-                throw new InvalidOperationException("Query is malformed.");
+                throw new InvalidOperationException($"Query is malformed.\r\n{string.Join("\r\n", diagnostics.Select(diag => $"{diag.Severity} {diag.Code} {diag.Message} {diag.Description}"))}");
             }
 
             var irVisitor = new IRTranslator();

--- a/src/BabyKusto.Core/DataSource/Column.cs
+++ b/src/BabyKusto.Core/DataSource/Column.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using BabyKusto.Core.Util;
 using Kusto.Language.Symbols;
 using Microsoft.Extensions.Internal;
 

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInAggregates.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInAggregates.cs
@@ -18,6 +18,15 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
         static BuiltInAggregates()
         {
             aggregates.Add(Aggregates.Count, new AggregateInfo(new AggregateOverloadInfo(new CountFunctionImpl(), ScalarTypes.Long)));
+            
+            aggregates.Add(Aggregates.CountIf, new AggregateInfo(new AggregateOverloadInfo(new CountIfFunctionImpl(), ScalarTypes.Long, ScalarTypes.Bool)));
+
+            aggregates.Add(
+                Aggregates.SumIf,
+                new AggregateInfo(
+                    new AggregateOverloadInfo(new SumIfIntFunctionImpl(), ScalarTypes.Int, ScalarTypes.Int, ScalarTypes.Bool),
+                    new AggregateOverloadInfo(new SumIfLongFunctionImpl(), ScalarTypes.Long, ScalarTypes.Long, ScalarTypes.Bool),
+                    new AggregateOverloadInfo(new SumIfDoubleFunctionImpl(), ScalarTypes.Real, ScalarTypes.Real, ScalarTypes.Bool)));
 
             aggregates.Add(
                 Aggregates.Avg,

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
@@ -35,6 +35,13 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new StrcatFunctionImpl(), ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String),
                     new ScalarOverloadInfo(new StrcatFunctionImpl(), ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String),
                     new ScalarOverloadInfo(new StrcatFunctionImpl(), ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String)));
+
+            var binFunctionInfo = new ScalarFunctionInfo(
+                new ScalarOverloadInfo(new BinIntFunctionImpl(), ScalarTypes.Int, ScalarTypes.Int, ScalarTypes.Int),
+                new ScalarOverloadInfo(new BinLongFunctionImpl(), ScalarTypes.Long, ScalarTypes.Long, ScalarTypes.Long),
+                new ScalarOverloadInfo(new BinDateTimeTimeSpanFunctionImpl(), ScalarTypes.DateTime, ScalarTypes.DateTime, ScalarTypes.TimeSpan));
+            functions.Add(Functions.Bin, binFunctionInfo);
+            functions.Add(Functions.Floor, binFunctionInfo);
         }
 
         public static ScalarOverloadInfo GetOverload(FunctionSymbol symbol, IRExpressionNode[] arguments, List<Parameter> parameters)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
@@ -37,6 +37,8 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new StrcatFunctionImpl(), ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String),
                     new ScalarOverloadInfo(new StrcatFunctionImpl(), ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String, ScalarTypes.String)));
 
+            functions.Add(Functions.Strlen, new ScalarFunctionInfo(new ScalarOverloadInfo(new StrlenFunctionImpl(), ScalarTypes.Long, ScalarTypes.String)));
+
             var binFunctionInfo = new ScalarFunctionInfo(
                 new ScalarOverloadInfo(new BinIntFunctionImpl(), ScalarTypes.Int, ScalarTypes.Int, ScalarTypes.Int),
                 new ScalarOverloadInfo(new BinLongFunctionImpl(), ScalarTypes.Long, ScalarTypes.Long, ScalarTypes.Long),

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInFunctions.cs
@@ -25,6 +25,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new MinOfDoubleFunctionImpl(), ScalarTypes.Real, ScalarTypes.Real, ScalarTypes.Real)));
 
             functions.Add(Functions.Now, new ScalarFunctionInfo(new ScalarOverloadInfo(new NowFunctionImpl(), ScalarTypes.DateTime)));
+            functions.Add(Functions.Ago, new ScalarFunctionInfo(new ScalarOverloadInfo(new AgoFunctionImpl(), ScalarTypes.DateTime, ScalarTypes.TimeSpan)));
 
             // TODO: Support N-ary functions properly
             functions.Add(

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
@@ -22,7 +22,8 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new UnaryMinusIntOperatorImpl(), ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new UnaryMinusLongOperatorImpl(), ScalarTypes.Long, ScalarTypes.Long),
-                    new ScalarOverloadInfo(new UnaryMinusDoubleOperatorImpl(), ScalarTypes.Real, ScalarTypes.Real)));
+                    new ScalarOverloadInfo(new UnaryMinusDoubleOperatorImpl(), ScalarTypes.Real, ScalarTypes.Real),
+                    new ScalarOverloadInfo(new UnaryMinusTimeSpanOperatorImpl(), ScalarTypes.TimeSpan, ScalarTypes.TimeSpan)));
 
             operators.Add(
                 Operators.Add,

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
@@ -71,28 +71,36 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new GreaterThanIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new GreaterThanLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
-                    new ScalarOverloadInfo(new GreaterThanDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real)));
+                    new ScalarOverloadInfo(new GreaterThanDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
+                    new ScalarOverloadInfo(new GreaterThanTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new GreaterThanDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
 
             operators.Add(
                 Operators.GreaterThanOrEqual,
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new GreaterThanOrEqualIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new GreaterThanOrEqualLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
-                    new ScalarOverloadInfo(new GreaterThanOrEqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real)));
+                    new ScalarOverloadInfo(new GreaterThanOrEqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
+                    new ScalarOverloadInfo(new GreaterThanOrEqualTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new GreaterThanOrEqualDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
 
             operators.Add(
                 Operators.LessThan,
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new LessThanIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new LessThanLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
-                    new ScalarOverloadInfo(new LessThanDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real)));
+                    new ScalarOverloadInfo(new LessThanDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
+                    new ScalarOverloadInfo(new LessThanTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new LessThanDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
 
             operators.Add(
                 Operators.LessThanOrEqual,
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new LessThanOrEqualIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new LessThanOrEqualLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
-                    new ScalarOverloadInfo(new LessThanOrEqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real)));
+                    new ScalarOverloadInfo(new LessThanOrEqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
+                    new ScalarOverloadInfo(new LessThanOrEqualTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new LessThanOrEqualDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
 
             operators.Add(
                 Operators.Equal,
@@ -100,7 +108,9 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new EqualIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new EqualLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
                     new ScalarOverloadInfo(new EqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
-                    new ScalarOverloadInfo(new EqualStringOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+                    new ScalarOverloadInfo(new EqualStringOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String),
+                    new ScalarOverloadInfo(new EqualTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new EqualDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
 
             operators.Add(
                 Operators.NotEqual,
@@ -108,7 +118,9 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new NotEqualIntOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Int, ScalarTypes.Int),
                     new ScalarOverloadInfo(new NotEqualLongOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Long, ScalarTypes.Long),
                     new ScalarOverloadInfo(new NotEqualDoubleOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Real, ScalarTypes.Real),
-                    new ScalarOverloadInfo(new NotEqualStringOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+                    new ScalarOverloadInfo(new NotEqualStringOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String),
+                    new ScalarOverloadInfo(new NotEqualTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
+                    new ScalarOverloadInfo(new NotEqualDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
         }
 
         public static ScalarOverloadInfo GetOverload(OperatorSymbol symbol, IRExpressionNode[] arguments, List<Parameter> parameters)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
@@ -132,6 +132,19 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                 Operators.Or,
                 new ScalarFunctionInfo(
                     new ScalarOverloadInfo(new LogicalOrOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Bool, ScalarTypes.Bool)));
+
+            operators.Add(Operators.Contains, new ScalarFunctionInfo(new ScalarOverloadInfo(new ContainsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.ContainsCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new ContainsCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotContains, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotContainsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotContainsCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotContainsCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.StartsWith, new ScalarFunctionInfo(new ScalarOverloadInfo(new StartsWithOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.StartsWithCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new StartsWithCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotStartsWith, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotStartsWithOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotStartsWithCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotStartsWithCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.EndsWith, new ScalarFunctionInfo(new ScalarOverloadInfo(new EndsWithOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.EndsWithCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new EndsWithCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotEndsWith, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotEndsWithOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
+            operators.Add(Operators.NotEndsWithCs, new ScalarFunctionInfo(new ScalarOverloadInfo(new NotEndsWithCsOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String)));
         }
 
         public static ScalarOverloadInfo GetOverload(OperatorSymbol symbol, IRExpressionNode[] arguments, List<Parameter> parameters)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInOperators.cs
@@ -121,6 +121,16 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     new ScalarOverloadInfo(new NotEqualStringOperatorImpl(), ScalarTypes.Bool, ScalarTypes.String, ScalarTypes.String),
                     new ScalarOverloadInfo(new NotEqualTimeSpanOperatorImpl(), ScalarTypes.Bool, ScalarTypes.TimeSpan, ScalarTypes.TimeSpan),
                     new ScalarOverloadInfo(new NotEqualDateTimeOperatorImpl(), ScalarTypes.Bool, ScalarTypes.DateTime, ScalarTypes.DateTime)));
+
+            operators.Add(
+                Operators.And,
+                new ScalarFunctionInfo(
+                    new ScalarOverloadInfo(new LogicalAndOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Bool, ScalarTypes.Bool)));
+
+            operators.Add(
+                Operators.Or,
+                new ScalarFunctionInfo(
+                    new ScalarOverloadInfo(new LogicalOrOperatorImpl(), ScalarTypes.Bool, ScalarTypes.Bool, ScalarTypes.Bool)));
         }
 
         public static ScalarOverloadInfo GetOverload(OperatorSymbol symbol, IRExpressionNode[] arguments, List<Parameter> parameters)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Aggregates/CountIf.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Aggregates/CountIf.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class CountIfFunctionImpl : IAggregateImpl
+    {
+        public ScalarResult Invoke(ITableChunk chunk, ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var column = (Column<bool>)arguments[0].Column;
+            long count = 0;
+            for (int i = 0; i < column.RowCount; i++)
+            {
+                if (column[i])
+                {
+                    count++;
+                }
+            }
+
+            return new ScalarResult(ScalarTypes.Long, count);
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Aggregates/SumIf.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Aggregates/SumIf.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class SumIfIntFunctionImpl : IAggregateImpl
+    {
+        public ScalarResult Invoke(ITableChunk chunk, ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+
+            var expression = (Column<int>)arguments[0].Column;
+            var predicate = (Column<bool>)arguments[1].Column;
+            int sum = 0;
+            for (int i = 0; i < predicate.RowCount; i++)
+            {
+                if (predicate[i])
+                {
+                    sum += expression[i];
+                }
+            }
+
+            return new ScalarResult(ScalarTypes.Int, sum);
+        }
+    }
+
+    internal class SumIfLongFunctionImpl : IAggregateImpl
+    {
+        public ScalarResult Invoke(ITableChunk chunk, ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+
+            var expression = (Column<long>)arguments[0].Column;
+            var predicate = (Column<bool>)arguments[1].Column;
+            long sum = 0;
+            for (int i = 0; i < predicate.RowCount; i++)
+            {
+                if (predicate[i])
+                {
+                    sum += expression[i];
+                }
+            }
+
+            return new ScalarResult(ScalarTypes.Long, sum);
+        }
+    }
+
+    internal class SumIfDoubleFunctionImpl : IAggregateImpl
+    {
+        public ScalarResult Invoke(ITableChunk chunk, ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+
+            var expression = (Column<double>)arguments[0].Column;
+            var predicate = (Column<bool>)arguments[1].Column;
+            double sum = 0;
+            for (int i = 0; i < predicate.RowCount; i++)
+            {
+                if (predicate[i])
+                {
+                    sum += expression[i];
+                }
+            }
+
+            return new ScalarResult(ScalarTypes.Real, sum);
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Ago.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Ago.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class AgoFunctionImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var ago = (TimeSpan)arguments[0].Value;
+            return new ScalarResult(ScalarTypes.DateTime, DateTime.UtcNow - ago);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var ago = (Column<TimeSpan>)arguments[0].Column;
+
+            var data = new DateTime[ago.RowCount];
+            var now = DateTime.UtcNow;
+            for (int i = 0; i < ago.RowCount; i++)
+            {
+                data[i] = now - ago[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.DateTime, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Bin.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Bin.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class BinIntFunctionImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (int)arguments[0].Value;
+            var right = (int)arguments[1].Value;
+
+            int floor;
+            if (right <= 0)
+            {
+                // TODO: Should be null (perhaps?)
+                floor = 0;
+            }
+            else
+            {
+                int remn = left % right;
+                if (remn < 0)
+                {
+                    remn += right;
+                }
+
+                floor = left - remn;
+            }
+
+            return new ScalarResult(ScalarTypes.Int, floor);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<int>)(arguments[0].Column);
+            var right = (Column<int>)(arguments[1].Column);
+
+            var data = new int[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                int floor;
+                if (right[i] <= 0)
+                {
+                    // TODO: Should be null (perhaps?)
+                    floor = 0;
+                }
+                else
+                {
+                    int remn = left[i] % right[i];
+                    if (remn < 0)
+                    {
+                        remn += right[i];
+                    }
+
+                    floor = left[i] - remn;
+                }
+
+                data[i] = floor;
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Int, data));
+        }
+    }
+
+    internal class BinLongFunctionImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (long)arguments[0].Value;
+            var right = (long)arguments[1].Value;
+
+            long floor;
+            if (right <= 0)
+            {
+                // TODO: Should be null (perhaps?)
+                floor = 0;
+            }
+            else
+            {
+                long remn = left % right;
+                if (remn < 0)
+                {
+                    remn += right;
+                }
+
+                floor = left - remn;
+            }
+
+            return new ScalarResult(ScalarTypes.Long, floor);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<long>)(arguments[0].Column);
+            var right = (Column<long>)(arguments[1].Column);
+
+            var data = new long[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                long floor;
+                if (right[i] <= 0)
+                {
+                    // TODO: Should be null (perhaps?)
+                    floor = 0;
+                }
+                else
+                {
+                    long remn = left[i] % right[i];
+                    if (remn < 0)
+                    {
+                        remn += right[i];
+                    }
+
+                    floor = left[i] - remn;
+                }
+
+                data[i] = floor;
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Long, data));
+        }
+    }
+
+    internal class BinDateTimeTimeSpanFunctionImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (DateTime)arguments[0].Value;
+            var right = (TimeSpan)arguments[1].Value;
+
+            long floor;
+            if (right.Ticks <= 0)
+            {
+                // TODO: Should be null (perhaps?)
+                floor = 0;
+            }
+            else
+            {
+                long remn = left.Ticks % right.Ticks;
+                if (remn < 0)
+                {
+                    remn += right.Ticks;
+                }
+
+                floor = left.Ticks - remn;
+            }
+
+            return new ScalarResult(ScalarTypes.DateTime, new DateTime(floor));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new DateTime[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                long floor;
+                if (right[i].Ticks <= 0)
+                {
+                    // TODO: Should be null (perhaps?)
+                    floor = 0;
+                }
+                else
+                {
+                    long remn = left[i].Ticks % right[i].Ticks;
+                    if (remn < 0)
+                    {
+                        remn += right[i].Ticks;
+                    }
+
+                    floor = left[i].Ticks - remn;
+                }
+
+                data[i] = new DateTime(floor);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.DateTime, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Strlen.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Strlen.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class StrlenFunctionImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var text = (string)arguments[0].Value;
+            return new ScalarResult(ScalarTypes.Long, (long)(text ?? String.Empty).Length);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var column = (Column<string>)arguments[0].Column;
+
+            var data = new long[column.RowCount];
+            for (int i = 0; i < column.RowCount; i++)
+            {
+                data[i] = (long)(column[i] ?? String.Empty).Length;
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Long, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Strlen.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Functions/Strlen.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -13,7 +12,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
         {
             Debug.Assert(arguments.Length == 1);
             var text = (string)arguments[0].Value;
-            return new ScalarResult(ScalarTypes.Long, (long)(text ?? String.Empty).Length);
+            return new ScalarResult(ScalarTypes.Long, (long)(text ?? string.Empty).Length);
         }
 
         public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
@@ -24,7 +23,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             var data = new long[column.RowCount];
             for (int i = 0; i < column.RowCount; i++)
             {
-                data[i] = (long)(column[i] ?? String.Empty).Length;
+                data[i] = (long)(column[i] ?? string.Empty).Length;
             }
             return new ColumnarResult(Column.Create(ScalarTypes.Long, data));
         }

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Contains.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Contains.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class ContainsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).ToUpperInvariant().Contains((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).ToUpperInvariant().Contains((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/ContainsCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/ContainsCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class ContainsCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).Contains(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).Contains(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/EndsWith.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/EndsWith.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class EndsWithOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).ToUpperInvariant().EndsWith((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).ToUpperInvariant().EndsWith((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/EndsWithCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/EndsWithCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class EndsWithCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).EndsWith(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).EndsWith(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Equal.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Equal.cs
@@ -84,7 +84,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
         public ScalarResult InvokeScalar(ScalarResult[] arguments)
         {
             Debug.Assert(arguments.Length == 2);
-            return new ScalarResult(ScalarTypes.Bool, (string)arguments[0].Value == (string)arguments[1].Value);
+            return new ScalarResult(ScalarTypes.Bool, ((string)arguments[0].Value ?? string.Empty) == ((string)arguments[1].Value ?? string.Empty));
         }
 
         public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
@@ -97,7 +97,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)
             {
-                data[i] = left[i] == right[i];
+                data[i] = (left[i] ?? string.Empty) == (right[i] ?? string.Empty);
             }
             return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
         }

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Equal.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/Equal.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -92,6 +93,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<string>)(arguments[0].Column);
             var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] == right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class EqualTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value == (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] == right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class EqualDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value == (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/GreaterThan.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/GreaterThan.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -68,6 +69,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<double>)(arguments[0].Column);
             var right = (Column<double>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] > right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class GreaterThanTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value > (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] > right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class GreaterThanDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value > (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/GreaterThanOrEqual.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/GreaterThanOrEqual.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -68,6 +69,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<double>)(arguments[0].Column);
             var right = (Column<double>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] >= right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class GreaterThanOrEqualTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value >= (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] >= right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class GreaterThanOrEqualDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value >= (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LessThan.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LessThan.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -68,6 +69,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<double>)(arguments[0].Column);
             var right = (Column<double>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] < right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class LessThanTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value < (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] < right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class LessThanDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value < (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LessThanOrEqual.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LessThanOrEqual.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -68,6 +69,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<double>)(arguments[0].Column);
             var right = (Column<double>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] <= right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class LessThanOrEqualTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value <= (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] <= right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class LessThanOrEqualDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value <= (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LogicalAnd.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LogicalAnd.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class LogicalAndOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (bool)arguments[0].Value && (bool)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<bool>)(arguments[0].Column);
+            var right = (Column<bool>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] && right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LogicalOr.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/LogicalOr.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class LogicalOrOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (bool)arguments[0].Value || (bool)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<bool>)(arguments[0].Column);
+            var right = (Column<bool>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] || right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotContains.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotContains.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotContainsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).ToUpperInvariant().Contains((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).ToUpperInvariant().Contains((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotContainsCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotContainsCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotContainsCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).Contains(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).Contains(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEndsWith.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEndsWith.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotEndsWithOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).ToUpperInvariant().EndsWith((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).ToUpperInvariant().EndsWith((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEndsWithCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEndsWithCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotEndsWithCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).EndsWith(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).EndsWith(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEqual.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEqual.cs
@@ -84,7 +84,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
         public ScalarResult InvokeScalar(ScalarResult[] arguments)
         {
             Debug.Assert(arguments.Length == 2);
-            return new ScalarResult(ScalarTypes.Bool, (string)arguments[0].Value != (string)arguments[1].Value);
+            return new ScalarResult(ScalarTypes.Bool, ((string)arguments[0].Value ?? string.Empty) != ((string)arguments[1].Value ?? string.Empty));
         }
 
         public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
@@ -97,7 +97,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)
             {
-                data[i] = left[i] != right[i];
+                data[i] = (left[i] ?? string.Empty) != (right[i] ?? string.Empty);
             }
             return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
         }

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEqual.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotEqual.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -92,6 +93,54 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
             Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
             var left = (Column<string>)(arguments[0].Column);
             var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] != right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class NotEqualTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (TimeSpan)arguments[0].Value != (TimeSpan)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<TimeSpan>)(arguments[0].Column);
+            var right = (Column<TimeSpan>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = left[i] != right[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+
+    internal class NotEqualDateTimeOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            return new ScalarResult(ScalarTypes.Bool, (DateTime)arguments[0].Value != (DateTime)arguments[1].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<DateTime>)(arguments[0].Column);
+            var right = (Column<DateTime>)(arguments[1].Column);
 
             var data = new bool[left.RowCount];
             for (int i = 0; i < left.RowCount; i++)

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotStartsWith.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotStartsWith.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotStartsWithOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).ToUpperInvariant().StartsWith((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).ToUpperInvariant().StartsWith((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotStartsWithCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/NotStartsWithCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class NotStartsWithCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, !(left ?? string.Empty).StartsWith(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = !(left[i] ?? string.Empty).StartsWith(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/StartsWith.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/StartsWith.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class StartsWithOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).ToUpperInvariant().StartsWith((right ?? string.Empty).ToUpperInvariant()));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).ToUpperInvariant().StartsWith((right[i] ?? string.Empty).ToUpperInvariant());
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/StartsWithCs.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/StartsWithCs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Kusto.Language.Symbols;
+
+namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
+{
+    internal class StartsWithCsOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            var left = (string)arguments[0].Value;
+            var right = (string)arguments[1].Value;
+            return new ScalarResult(ScalarTypes.Bool, (left ?? string.Empty).StartsWith(right ?? string.Empty));
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 2);
+            Debug.Assert(arguments[0].Column.RowCount == arguments[1].Column.RowCount);
+            var left = (Column<string>)(arguments[0].Column);
+            var right = (Column<string>)(arguments[1].Column);
+
+            var data = new bool[left.RowCount];
+            for (int i = 0; i < left.RowCount; i++)
+            {
+                data[i] = (left[i] ?? string.Empty).StartsWith(right[i] ?? string.Empty);
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.Bool, data));
+        }
+    }
+}

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/UnaryMinus.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/Impl/Operators/UnaryMinus.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using Kusto.Language.Symbols;
 
@@ -69,6 +70,28 @@ namespace BabyKusto.Core.Evaluation.BuiltIns.Impl
                 data[i] = -column[i];
             }
             return new ColumnarResult(Column.Create(ScalarTypes.Real, data));
+        }
+    }
+
+    internal class UnaryMinusTimeSpanOperatorImpl : IScalarFunctionImpl
+    {
+        public ScalarResult InvokeScalar(ScalarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            return new ScalarResult(ScalarTypes.TimeSpan, -(TimeSpan)arguments[0].Value);
+        }
+
+        public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+        {
+            Debug.Assert(arguments.Length == 1);
+            var column = (Column<TimeSpan>)(arguments[0].Column);
+
+            var data = new TimeSpan[column.RowCount];
+            for (int i = 0; i < column.RowCount; i++)
+            {
+                data[i] = -column[i];
+            }
+            return new ColumnarResult(Column.Create(ScalarTypes.TimeSpan, data));
         }
     }
 }

--- a/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.Cast.cs
+++ b/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.Cast.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using BabyKusto.Core.InternalRepresentation;
+using BabyKusto.Core.Util;
 using Kusto.Language.Symbols;
 
 namespace BabyKusto.Core.Evaluation
@@ -12,7 +13,7 @@ namespace BabyKusto.Core.Evaluation
     {
         public override EvaluationResult VisitCastExpression(IRCastExpressionNode node, EvaluationContext context)
         {
-            var impl = node.GetOrSetCache(
+            var impl = node.GetOrSetCache<Func<EvaluationResult[], EvaluationResult>>(
                 () =>
                 {
                     if (node.ResultKind == EvaluatedExpressionKind.Scalar)
@@ -22,7 +23,7 @@ namespace BabyKusto.Core.Evaluation
                             return (EvaluationResult[] arguments) =>
                             {
                                 Debug.Assert(arguments.Length == 1);
-                                return (EvaluationResult)new ScalarResult(node.ResultType, Convert.ToInt32(((ScalarResult)arguments[0]).Value));
+                                return new ScalarResult(node.ResultType, Convert.ToInt32(((ScalarResult)arguments[0]).Value));
                             };
                         }
                         else if (node.ResultType == ScalarTypes.Long)
@@ -30,7 +31,7 @@ namespace BabyKusto.Core.Evaluation
                             return (EvaluationResult[] arguments) =>
                             {
                                 Debug.Assert(arguments.Length == 1);
-                                return (EvaluationResult)new ScalarResult(node.ResultType, Convert.ToInt64(((ScalarResult)arguments[0]).Value));
+                                return new ScalarResult(node.ResultType, Convert.ToInt64(((ScalarResult)arguments[0]).Value));
                             };
                         }
                         else if (node.ResultType == ScalarTypes.Real)
@@ -38,7 +39,7 @@ namespace BabyKusto.Core.Evaluation
                             return (EvaluationResult[] arguments) =>
                             {
                                 Debug.Assert(arguments.Length == 1);
-                                return (EvaluationResult)new ScalarResult(node.ResultType, Convert.ToDouble(((ScalarResult)arguments[0]).Value));
+                                return new ScalarResult(node.ResultType, Convert.ToDouble(((ScalarResult)arguments[0]).Value));
                             };
                         }
                         else if (node.ResultType == ScalarTypes.String)
@@ -46,7 +47,7 @@ namespace BabyKusto.Core.Evaluation
                             return (EvaluationResult[] arguments) =>
                             {
                                 Debug.Assert(arguments.Length == 1);
-                                return (EvaluationResult)new ScalarResult(node.ResultType, Convert.ToString(((ScalarResult)arguments[0]).Value));
+                                return new ScalarResult(node.ResultType, Convert.ToString(((ScalarResult)arguments[0]).Value));
                             };
                         }
                         else
@@ -64,7 +65,7 @@ namespace BabyKusto.Core.Evaluation
                                 var columnResult = (ColumnarResult)arguments[0];
                                 var builder = new ColumnBuilder<int>(node.ResultType);
                                 columnResult.Column.ForEach(item => builder.Add(Convert.ToInt32(item)));
-                                return (EvaluationResult)new ColumnarResult(builder.ToColumn());
+                                return new ColumnarResult(builder.ToColumn());
                             };
                         }
                         else if (node.ResultType == ScalarTypes.Long)
@@ -75,7 +76,7 @@ namespace BabyKusto.Core.Evaluation
                                 var columnResult = (ColumnarResult)arguments[0];
                                 var builder = new ColumnBuilder<long>(node.ResultType);
                                 columnResult.Column.ForEach(item => builder.Add(Convert.ToInt64(item)));
-                                return (EvaluationResult)new ColumnarResult(builder.ToColumn());
+                                return new ColumnarResult(builder.ToColumn());
                             };
                         }
                         else if (node.ResultType == ScalarTypes.Real)
@@ -86,7 +87,7 @@ namespace BabyKusto.Core.Evaluation
                                 var columnResult = (ColumnarResult)arguments[0];
                                 var builder = new ColumnBuilder<double>(node.ResultType);
                                 columnResult.Column.ForEach(item => builder.Add(Convert.ToDouble(item)));
-                                return (EvaluationResult)new ColumnarResult(builder.ToColumn());
+                                return new ColumnarResult(builder.ToColumn());
                             };
                         }
                         else if (node.ResultType == ScalarTypes.String)
@@ -97,7 +98,7 @@ namespace BabyKusto.Core.Evaluation
                                 var columnResult = (ColumnarResult)arguments[0];
                                 var builder = new ColumnBuilder<string>(node.ResultType);
                                 columnResult.Column.ForEach(item => builder.Add(Convert.ToString(item)));
-                                return (EvaluationResult)new ColumnarResult(builder.ToColumn());
+                                return new ColumnarResult(builder.ToColumn());
                             };
                         }
                         else

--- a/src/BabyKusto.Core/Evaluation/TreeEvaluator.QueryOperators.Filter.cs
+++ b/src/BabyKusto.Core/Evaluation/TreeEvaluator.QueryOperators.Filter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using BabyKusto.Core.Extensions;
 using BabyKusto.Core.InternalRepresentation;
+using BabyKusto.Core.Util;
 using Kusto.Language.Symbols;
 
 namespace BabyKusto.Core.Evaluation

--- a/src/BabyKusto.Core/InternalRepresentation/Nodes/Expressions/IRAggregateCallNode.cs
+++ b/src/BabyKusto.Core/InternalRepresentation/Nodes/Expressions/IRAggregateCallNode.cs
@@ -11,7 +11,7 @@ namespace BabyKusto.Core.InternalRepresentation
     internal class IRAggregateCallNode : IRExpressionNode
     {
         public IRAggregateCallNode(Signature signature, AggregateOverloadInfo overloadInfo, IReadOnlyList<Parameter> parameters, IRListNode<IRExpressionNode> arguments, TypeSymbol resultType)
-            : base(resultType, GetResultKind(arguments))
+            : base(resultType, EvaluatedExpressionKind.Scalar)
         {
             Signature = signature ?? throw new ArgumentNullException(nameof(signature));
             OverloadInfo = overloadInfo ?? throw new ArgumentNullException(nameof(overloadInfo));

--- a/src/BabyKusto.Core/Util/ColumnBuilder.cs
+++ b/src/BabyKusto.Core/Util/ColumnBuilder.cs
@@ -4,15 +4,15 @@
 using System.Collections.Generic;
 using Kusto.Language.Symbols;
 
-namespace BabyKusto.Core
+namespace BabyKusto.Core.Util
 {
-    internal abstract class ColumnBuilder
+    public abstract class ColumnBuilder
     {
         public abstract void Add(object value);
         public abstract Column ToColumn();
     }
 
-    internal class ColumnBuilder<T> : ColumnBuilder
+    public class ColumnBuilder<T> : ColumnBuilder
     {
         private readonly List<T> _data = new();
 

--- a/src/BabyKusto.Core/Util/ColumnHelpers.cs
+++ b/src/BabyKusto.Core/Util/ColumnHelpers.cs
@@ -22,9 +22,9 @@ namespace BabyKusto.Core.Util
             {
                 return CreateFromDoublesObjectArray(data, typeSymbol);
             }
-            else if (typeSymbol == ScalarTypes.DateTime)
+            else if (typeSymbol == ScalarTypes.Bool)
             {
-                return CreateFromObjectArray<DateTime>(data, typeSymbol);
+                return CreateFromBoolsObjectArray(data, typeSymbol);
             }
             else if (typeSymbol == ScalarTypes.String)
             {
@@ -33,6 +33,10 @@ namespace BabyKusto.Core.Util
             else if (typeSymbol == ScalarTypes.DateTime)
             {
                 return CreateFromObjectArray<DateTime>(data, typeSymbol);
+            }
+            else if (typeSymbol == ScalarTypes.TimeSpan)
+            {
+                return CreateFromObjectArray<TimeSpan>(data, typeSymbol);
             }
             else
             {
@@ -58,10 +62,6 @@ namespace BabyKusto.Core.Util
             else if (typeSymbol == ScalarTypes.Bool)
             {
                 return CreateFromBool(value, typeSymbol, numRows);
-            }
-            else if (typeSymbol == ScalarTypes.DateTime)
-            {
-                return CreateFromScalar<DateTime>((DateTime)value, typeSymbol, numRows);
             }
             else if (typeSymbol == ScalarTypes.String)
             {
@@ -100,13 +100,13 @@ namespace BabyKusto.Core.Util
             {
                 return new ColumnBuilder<bool>(typeSymbol);
             }
-            else if (typeSymbol == ScalarTypes.DateTime)
-            {
-                return new ColumnBuilder<DateTime>(typeSymbol);
-            }
             else if (typeSymbol == ScalarTypes.String)
             {
                 return new ColumnBuilder<string>(typeSymbol);
+            }
+            else if (typeSymbol == ScalarTypes.DateTime)
+            {
+                return new ColumnBuilder<DateTime>(typeSymbol);
             }
             else if (typeSymbol == ScalarTypes.TimeSpan)
             {
@@ -158,6 +158,17 @@ namespace BabyKusto.Core.Util
             for (int i = 0; i < data.Length; i++)
             {
                 columnData[i] = Convert.ToDouble(data[i]);
+            }
+
+            return Column.Create(typeSymbol, columnData);
+        }
+
+        private static Column<bool> CreateFromBoolsObjectArray(object[] data, TypeSymbol typeSymbol)
+        {
+            var columnData = new bool[data.Length];
+            for (int i = 0; i < data.Length; i++)
+            {
+                columnData[i] = Convert.ToBoolean(data[i]);
             }
 
             return Column.Create(typeSymbol, columnData);

--- a/src/BabyKusto.Core/Util/ColumnHelpers.cs
+++ b/src/BabyKusto.Core/Util/ColumnHelpers.cs
@@ -6,9 +6,9 @@ using Kusto.Language.Symbols;
 
 namespace BabyKusto.Core.Util
 {
-    internal static class ColumnHelpers
+    public static class ColumnHelpers
     {
-        internal static Column CreateFromObjectArray(object[] data, TypeSymbol typeSymbol)
+        public static Column CreateFromObjectArray(object[] data, TypeSymbol typeSymbol)
         {
             if (typeSymbol == ScalarTypes.Int)
             {
@@ -41,7 +41,7 @@ namespace BabyKusto.Core.Util
             }
         }
 
-        internal static Column CreateFromScalar(object value, TypeSymbol typeSymbol, int numRows)
+        public static Column CreateFromScalar(object value, TypeSymbol typeSymbol, int numRows)
         {
             if (typeSymbol == ScalarTypes.Int)
             {
@@ -82,7 +82,7 @@ namespace BabyKusto.Core.Util
             }
         }
 
-        internal static ColumnBuilder CreateBuilder(TypeSymbol typeSymbol)
+        public static ColumnBuilder CreateBuilder(TypeSymbol typeSymbol)
         {
             if (typeSymbol == ScalarTypes.Int)
             {

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -218,6 +218,53 @@ vAvg:real; vCount:long; vSum:real
         }
 
         [Fact]
+        public void BuiltInAggregates_countif()
+        {
+            // Arrange
+            string query = @"
+datatable(a: bool)
+[
+    true, true, false, true
+]
+| summarize v=countif(a)
+";
+
+            string expected = @"
+v:long
+------------------
+3
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BuiltInAggregates_sumif_Long()
+        {
+            // Arrange
+            string query = @"
+datatable(v:long, include: bool)
+[
+    1, true,
+    2, false,
+    4, true,
+    8, true,
+]
+| summarize v=sumif(v, include)
+";
+
+            string expected = @"
+v:long
+------------------
+13
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
         public void Take_Works()
         {
             // Arrange

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -626,6 +626,48 @@ b-456
         }
 
         [Fact]
+        public void BuiltIns_strlen_Scalar()
+        {
+            // Arrange
+            string query = @"
+print v=strlen('abc')
+";
+
+            string expected = @"
+v:long
+------------------
+3
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BuiltIns_strlen_Columnar()
+        {
+            // Arrange
+            string query = @"
+datatable(a:string)
+[
+    'a',
+    'abc',
+]
+| project v = strlen(a)
+";
+
+            string expected = @"
+v:long
+------------------
+1
+3
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
         public void BuiltIns_bin_Long()
         {
             // Arrange

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -1090,6 +1090,174 @@ True
         }
 
         [Fact]
+        public void BinOp_StringContains()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'a',
+    'ac',
+    'bc',
+    'BC',
+]
+| project v = 'abcd' contains v, notV = 'abcd' !contains v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+False; True
+True; False
+True; False
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BinOp_StringContainsCs()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'a',
+    'ac',
+    'bc',
+    'BC',
+]
+| project v = 'abcd' contains_cs v, notV = 'abcd' !contains_cs v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+False; True
+True; False
+False; True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BinOp_StringStartsWith()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'a',
+    'ab',
+    'ABC',
+    'bc',
+]
+| project v = 'abcd' startswith v, notV = 'abcd' !startswith v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+True; False
+True; False
+False; True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BinOp_StringStartsWithCs()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'a',
+    'ab',
+    'ABC',
+    'bc',
+]
+| project v = 'abcd' startswith_cs v, notV = 'abcd' !startswith_cs v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+True; False
+False; True
+False; True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BinOp_StringEndsWith()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'd',
+    'cd',
+    'BCD',
+    'bc',
+]
+| project v = 'abcd' endswith v, notV = 'abcd' !endswith v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+True; False
+True; False
+False; True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact(Skip = "Kusto library bug, see: https://github.com/microsoft/Kusto-Query-Language/issues/66")]
+        public void BinOp_StringEndsWithCs()
+        {
+            // Arrange
+            string query = @"
+datatable(v:string)
+[
+    'd',
+    'cd',
+    'BCD',
+    'bc',
+]
+| project v = 'abcd' endswith_cs v, notV = 'abcd' !endswith_cs v
+";
+
+            string expected = @"
+v:bool; notV:bool
+------------------
+True; False
+True; False
+False; True
+False; True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
         public void ToScalar_Tabular()
         {
             // Arrange

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -579,6 +579,54 @@ b-456
         }
 
         [Fact]
+        public void BuiltIns_bin_Long()
+        {
+            // Arrange
+            string query = @"
+datatable(a:long, b:long)
+[
+  -1, 3,
+   0, 3,
+   1, 3,
+   2, 3,
+   3, 3,
+   4, 3,
+]
+| project v1 = bin(a, b), v2 = floor(a, b)";
+
+            string expected = @"
+v1:long; v2:long
+------------------
+-3; -3
+0; 0
+0; 0
+0; 0
+3; 3
+3; 3
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BuiltIns_bin_DateTime()
+        {
+            // Arrange
+            string query = @"
+print v=bin(datetime(2022-03-02 23:04), 1h)";
+
+            string expected = @"
+v:datetime
+------------------
+2022-03-02 23:00:00Z
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
         public void UserDefinedFunction1()
         {
             // Arrange

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -1335,6 +1335,25 @@ v:real
             Test(query, expected);
         }
 
+        [Fact]
+        public void AggregateFunctionResultKind()
+        {
+            // Arrange
+            string query = @"
+datatable(a:long) [ 1, 2, 3 ]
+| summarize v=100 * count()
+";
+
+            string expected = @"
+v:long
+------------------
+300
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
         private static void Test(string query, string expectedOutput)
         {
             var engine = new BabyKustoEngine();

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -939,6 +939,62 @@ b
         }
 
         [Fact]
+        public void BinOp_LogicalAnd()
+        {
+            // Arrange
+            string query = @"
+datatable(a:bool, b:bool)
+[
+    false, false,
+    false, true,
+    true, false,
+    true, true,
+]
+| project v = a and b
+";
+
+            string expected = @"
+v:bool
+------------------
+False
+False
+False
+True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
+        public void BinOp_LogicalOr()
+        {
+            // Arrange
+            string query = @"
+datatable(a:bool, b:bool)
+[
+    false, false,
+    false, true,
+    true, false,
+    true, true,
+]
+| project v = a or b
+";
+
+            string expected = @"
+v:bool
+------------------
+False
+True
+True
+True
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
+        [Fact]
         public void ToScalar_Tabular()
         {
             // Arrange


### PR DESCRIPTION
* When query parsing fails, bubble out an exception including Kusto diagnostics
* Implemented many operators: overloads for DateTime and TimeSpan, logical `and` / `or`, string operators like `startswith`, `contains`, etc.
* Implemented new aggregate functions `countif`, `sumif`
* Implemented new scalar functions `ago`, `bin`, `strlen`
* Fixed bug where aggregate functions were annotated incorrectly in the internal representation as possibly returning columnar results, whereas it's always scalar
* Many new tests

NOTE: Operator `!endswith_cs` doesn't work yet because of [a bug in the Kusto library](https://github.com/microsoft/Kusto-Query-Language/issues/66).