### PR TITLE
Stricter type assertions

### DIFF
--- a/samples/BabyKusto.ProcessQuerier/Program.cs
+++ b/samples/BabyKusto.ProcessQuerier/Program.cs
@@ -72,7 +72,7 @@ static void ExecuteReplQuery(string query)
     var processesTable = GetProcessesTable();
     var engine = new BabyKustoEngine();
     engine.AddGlobalTable("Processes", processesTable);
-    var result = engine.Evaluate(query, dumpIRTree: true); // Set dumpIRTree = true to see the internal tree representation
+    var result = engine.Evaluate(query, dumpIRTree: false); // Set dumpIRTree = true to see the internal tree representation
 
     Console.WriteLine();
 

--- a/samples/BabyKusto.ProcessQuerier/Program.cs
+++ b/samples/BabyKusto.ProcessQuerier/Program.cs
@@ -72,7 +72,7 @@ static void ExecuteReplQuery(string query)
     var processesTable = GetProcessesTable();
     var engine = new BabyKustoEngine();
     engine.AddGlobalTable("Processes", processesTable);
-    var result = engine.Evaluate(query, dumpIRTree: false); // Set dumpIRTree = true to see the internal tree representation
+    var result = engine.Evaluate(query, dumpIRTree: true); // Set dumpIRTree = true to see the internal tree representation
 
     Console.WriteLine();
 

--- a/src/BabyKusto.Core/DataSource/TableChunk.cs
+++ b/src/BabyKusto.Core/DataSource/TableChunk.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Kusto.Language.Symbols;
 
 namespace BabyKusto.Core
 {
@@ -9,10 +10,7 @@ namespace BabyKusto.Core
     {
         public TableChunk(ITableSource table, Column[] columns)
         {
-            if (table.Type.Members.Count != columns.Length)
-            {
-                throw new ArgumentException($"Expected schema and columns to have the same lengths, found {table.Type.Members.Count} and {columns.Length}.");
-            }
+            ValidateTypes(table.Type, columns);
 
             Table = table;
             Columns = columns;
@@ -23,5 +21,21 @@ namespace BabyKusto.Core
         public Column[] Columns { get; }
 
         public int RowCount => Columns.Length == 0 ? 0 : Columns[0].RowCount;
+
+        private static void ValidateTypes(TableSymbol tableSymbol, Column[] columns)
+        {
+            if (columns.Length != tableSymbol.Columns.Count)
+            {
+                throw new ArgumentException($"Invalid number of columns in chunk, got {columns.Length}, expected {tableSymbol.Columns.Count} per table schema.");
+            }
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                if (columns[i].Type != tableSymbol.Columns[i].Type)
+                {
+                    throw new ArgumentException($"Mismatched column[{i}] type in chunk, got {columns[i].Type.Display}, expected {tableSymbol.Columns[i].Type.Display}.");
+                }
+            }
+        }
     }
 }

--- a/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
+++ b/src/BabyKusto.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
@@ -52,7 +52,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
         }
 
         // TODO: Support named parameters
-        public static Func<EvaluationResult[], EvaluationResult> GetScalarImplementation(IRExpressionNode[] argumentExpressions, IScalarFunctionImpl impl, EvaluatedExpressionKind resultKind)
+        public static Func<EvaluationResult[], EvaluationResult> GetScalarImplementation(IRExpressionNode[] argumentExpressions, IScalarFunctionImpl impl, EvaluatedExpressionKind resultKind, TypeSymbol expectedResultType)
         {
             if (resultKind == EvaluatedExpressionKind.Scalar)
             {
@@ -65,7 +65,9 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                     {
                         scalarArgs[i] = (ScalarResult)arguments[i];
                     }
-                    return impl.InvokeScalar(scalarArgs);
+                    var result = impl.InvokeScalar(scalarArgs);
+                    Debug.Assert(result.Type == expectedResultType, $"Evaluation produced wrong type {result.Type.Display}, expected {expectedResultType.Display}");
+                    return result;
                 };
             }
             else if (resultKind == EvaluatedExpressionKind.Columnar)
@@ -112,7 +114,9 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                         }
                     }
 
-                    return impl.InvokeColumnar(columnarArgs);
+                    var result = impl.InvokeColumnar(columnarArgs);
+                    Debug.Assert(result.Type == expectedResultType, $"Evaluation produced wrong type {result.Type.Display}, expected {expectedResultType.Display}");
+                    return result;
                 };
             }
             else
@@ -121,7 +125,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
             }
         }
 
-        public static Func<EvaluationResult[], EvaluationResult> GetWindowImplementation(IRExpressionNode[] argumentExpressions, IWindowFunctionImpl impl, EvaluatedExpressionKind resultKind)
+        public static Func<EvaluationResult[], EvaluationResult> GetWindowImplementation(IRExpressionNode[] argumentExpressions, IWindowFunctionImpl impl, EvaluatedExpressionKind resultKind, TypeSymbol expectedResultType)
         {
             if (resultKind != EvaluatedExpressionKind.Columnar)
             {
@@ -173,6 +177,7 @@ namespace BabyKusto.Core.Evaluation.BuiltIns
                 }
 
                 var result = impl.InvokeWindow(columnarArgs, lastWindowArgs, previousResult);
+                Debug.Assert(result.Type == expectedResultType, $"Evaluation produced wrong type {result.Type.Display}, expected {expectedResultType.Display}");
                 lastWindowArgs = columnarArgs;
                 previousResult = result;
                 return result;

--- a/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
+++ b/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
@@ -23,9 +23,7 @@ namespace BabyKusto.Core.Evaluation
                         argumentExpressions[i] = node.Arguments.GetTypedChild(i);
                     }
 
-                    var impl = node.OverloadInfo.ScalarImpl;
-                    var resultKind = node.ResultKind;
-                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, impl, resultKind);
+                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, node.OverloadInfo.ScalarImpl, node.ResultKind, node.ResultType);
                 });
 
             var arguments = new EvaluationResult[node.Arguments.ChildCount];
@@ -50,9 +48,7 @@ namespace BabyKusto.Core.Evaluation
                         argumentExpressions[i] = node.Arguments.GetTypedChild(i);
                     }
 
-                    var impl = node.OverloadInfo.Impl;
-                    var resultKind = node.ResultKind;
-                    return BuiltInsHelper.GetWindowImplementation(argumentExpressions, impl, resultKind);
+                    return BuiltInsHelper.GetWindowImplementation(argumentExpressions, node.OverloadInfo.Impl, node.ResultKind, node.ResultType);
                 });
 
             var arguments = new EvaluationResult[node.Arguments.ChildCount];

--- a/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
+++ b/src/BabyKusto.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
@@ -15,10 +15,7 @@ namespace BabyKusto.Core.Evaluation
                 () =>
                 {
                     var argumentExpressions = new IRExpressionNode[] { node.Expression };
-                    var impl = node.OverloadInfo.ScalarImpl;
-                    var resultKind = node.ResultKind;
-
-                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, impl, resultKind);
+                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, node.OverloadInfo.ScalarImpl, node.ResultKind, node.ResultType);
                 });
 
             var val = node.Expression.Accept(this, context);
@@ -33,10 +30,7 @@ namespace BabyKusto.Core.Evaluation
                 () =>
                 {
                     var argumentExpressions = new IRExpressionNode[] { node.Left, node.Right };
-                    var impl = node.OverloadInfo.ScalarImpl;
-                    var resultKind = node.ResultKind;
-
-                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, impl, resultKind);
+                    return BuiltInsHelper.GetScalarImplementation(argumentExpressions, node.OverloadInfo.ScalarImpl, node.ResultKind, node.ResultType);
                 });
 
             var leftVal = node.Left.Accept(this, context);

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -872,7 +872,7 @@ v:datetime
             Test(query, expected);
         }
 
-        [Fact(Skip = "We don't support type narrowing yet")]
+        [Fact(Skip = "See: https://github.com/microsoft/Kusto-Query-Language/issues/67")]
         public void BuiltIns_bin_Narrowing()
         {
             // Arrange
@@ -881,7 +881,7 @@ datatable(a:int) [ 9, 10, 11 ]
 | project v = bin(a, 10)";
 
             string expected = @"
-v:int
+v:long
 ------------------
 0
 10

--- a/test/BabyKusto.Core.Tests/EndToEndTests.cs
+++ b/test/BabyKusto.Core.Tests/EndToEndTests.cs
@@ -872,6 +872,26 @@ v:datetime
             Test(query, expected);
         }
 
+        [Fact(Skip = "We don't support type narrowing yet")]
+        public void BuiltIns_bin_Narrowing()
+        {
+            // Arrange
+            string query = @"
+datatable(a:int) [ 9, 10, 11 ]
+| project v = bin(a, 10)";
+
+            string expected = @"
+v:int
+------------------
+0
+10
+10
+";
+
+            // Act & Assert
+            Test(query, expected);
+        }
+
         [Fact]
         public void UserDefinedFunction1()
         {


### PR DESCRIPTION
Fail fast and detect engine bugs where the result type we produce disagrees with Kusto analysis expectations. For example, we don't support type narrowing yet which causes wrong result types in many cases.

In the future, we may want to not rely on Kusto analysis for result type computations, and could instead allow the engine to be self-consistent even if it would be incompatible with Kusto. This is not the preferred choice atm.

Until we come up with something better, this PR at least makes easier to identify anywhere we have these issues.